### PR TITLE
Fix missing cookieparser dependency.

### DIFF
--- a/express-web/app.js
+++ b/express-web/app.js
@@ -1,5 +1,8 @@
 var express = require('express');
+var cookieParser = require('cookie-parser');
 var app = express();
+app.use(cookieParser());
+
 var Snoocore = require('snoocore');
 
 var uniqId = 0; // unique id for our user

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "homepage": "https://github.com/trevorsenior/snoocore-examples",
   "dependencies": {
     "bluebird": "^2.9.30",
+    "cookieparser": "^0.1.0",
     "express": "^4.12.4",
     "open": "0.0.5",
     "snoocore": "3.2.0",


### PR DESCRIPTION
[req.cookies](https://github.com/trevorsenior/snoocore-examples/blob/master/express-web/app.js#L31) depends on cookieparser middleware.

Fix contains following bits:

- Add cookieparser dependency to packages.json.
- Ensure cookieparser is loaded in express-sample.